### PR TITLE
Do not attempt to inject HTML into streaming responses

### DIFF
--- a/cavalry_tests/urls.py
+++ b/cavalry_tests/urls.py
@@ -1,8 +1,17 @@
 from django.contrib import admin
+from django.http import StreamingHttpResponse
+from django.template.loader import render_to_string
 from django.urls import path
 from django.views.generic import TemplateView
+
+
+def streaming_view(request):
+    content = render_to_string("index.html", request=request)
+    return StreamingHttpResponse(iter(content), content_type="text/html")
+
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", TemplateView.as_view(template_name="index.html")),
+    path("streaming/", streaming_view),
 ]


### PR DESCRIPTION
We didn't check for streaming responses properly; we can't inject and reassemble such things, so skip the HTML injection altogether.