### PR TITLE
Add support for `request._cavalry_can_inject_stats`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.4
+    rev: v0.6.7
     hooks:
       - id: ruff
         args:
@@ -18,6 +18,6 @@ repos:
         args:
           - --fix=lf
   - repo: https://github.com/crate-ci/typos
-    rev: v1.23.3
+    rev: v1.24.6
     hooks:
       - id: typos

--- a/README.md
+++ b/README.md
@@ -76,8 +76,16 @@ Not posting stack traces makes the ES payloads smaller.
 
 ## Runtime
 
-When running in `DEBUG`, or when you're a superuser, Cavalry injects a small perf bar
-into each rendered HTML page, as well as a script segment that outputs SQL queries into the dev console.
+When
 
-By default, stack traces are not printed for the SQL queries; add the `_cavalry_stacks` query parameter to have
-them printed too.
+* running in `DEBUG`, or
+* when you're a superuser, or
+* if `request._cavalry_can_inject_stats` is truthy (e.g. via a middleware of your own design)
+  * Note that this may, especially in conjunction with `_cavalry_stacks`, reveal sensitive information.
+    Be very diligent with that middleware.
+
+Cavalry injects a small perf bar into each rendered HTML page,
+as well as a script segment that outputs SQL queries into the dev console.
+
+By default, stack traces are not printed for the SQL queries;
+add the `_cavalry_stacks` query parameter to have them printed too.

--- a/cavalry/policy.py
+++ b/cavalry/policy.py
@@ -42,6 +42,9 @@ def can_inject_stats(request: WSGIRequest) -> bool:
     if settings.DEBUG:
         return True
 
+    if getattr(request, "_cavalry_can_inject_stats", False):
+        return True
+
     # When the user (if there is one) is a superuser, stats can be shown
     user = getattr(request, "user", None)
     if user and getattr(user, "is_superuser", False):

--- a/cavalry_tests/tests/test_cavalry.py
+++ b/cavalry_tests/tests/test_cavalry.py
@@ -6,7 +6,7 @@ from django.http import StreamingHttpResponse
 from django.test import Client
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 @pytest.mark.parametrize("enable", [False, True], ids=("disabled", "enabled"))
 @pytest.mark.parametrize("as_admin", [False, True], ids=("as_user", "as_admin"))
 @pytest.mark.parametrize("posting", [False, True], ids=("nopost", "posting"))

--- a/cavalry_tests/tests/test_cavalry.py
+++ b/cavalry_tests/tests/test_cavalry.py
@@ -2,8 +2,22 @@ import json
 
 import pytest
 import requests_mock
-from django.http import StreamingHttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 from django.test import Client
+
+
+def assert_response_content(
+    resp: HttpResponse,
+    content: bytes,
+    *,
+    should_expose_info: bool,
+    should_have_html: bool,
+) -> None:
+    assert (b"<div" in content) == should_have_html
+    # Check the header is present when it should be, and is parseable
+    assert ("x-cavalry-data" in resp) == should_expose_info
+    if "x-cavalry-data" in resp:
+        assert json.loads(resp["x-cavalry-data"])
 
 
 @pytest.mark.django_db
@@ -35,13 +49,13 @@ def test_cavalry(settings, as_admin, enable, posting, admin_user, streaming):
     # Check precondition: the user seemed logged in
     assert (f"Henlo {admin_user.username}".encode() in content) == as_admin
 
-    should_expose_info = enable and as_admin
     # Check that the injection div/header only appears for admins and when not streaming
-    assert (b"<div" in content) == (should_expose_info and not streaming)
-    # Check the header is present when it should be, and is parseable
-    assert ("x-cavalry-data" in resp) == should_expose_info
-    if "x-cavalry-data" in resp:
-        assert json.loads(resp["x-cavalry-data"])
+    assert_response_content(
+        resp,
+        content,
+        should_expose_info=(enable and as_admin),
+        should_have_html=(enable and as_admin and not streaming),
+    )
 
     # Check that stats are posted only when posting is enabled
     assert bool(m.called) == (enable and posting)
@@ -52,3 +66,21 @@ def test_cavalry(settings, as_admin, enable, posting, admin_user, streaming):
         database_info = payload["databases"]["default"]
         if database_info["n_queries"]:
             assert database_info["time"] > 0
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("arg", ["", "?plsplspls=1"])
+def test_can_inject_stats_override(settings, client, arg):
+    """
+    Test that a view (or a middleware) can enable stats injection
+    despite the user not being a superuser, or DEBUG being off.
+    """
+    settings.CAVALRY_ENABLED = True
+    settings.DEBUG = False
+    resp = client.get(f"/overrider/{arg}")
+    assert_response_content(
+        resp,
+        resp.content,
+        should_expose_info=bool(arg),
+        should_have_html=bool(arg),
+    )

--- a/cavalry_tests/urls.py
+++ b/cavalry_tests/urls.py
@@ -4,14 +4,26 @@ from django.template.loader import render_to_string
 from django.urls import path
 from django.views.generic import TemplateView
 
+regular_view = TemplateView.as_view(template_name="index.html")
+
 
 def streaming_view(request):
     content = render_to_string("index.html", request=request)
     return StreamingHttpResponse(iter(content), content_type="text/html")
 
 
+def overrider_view(request):
+    """
+    A view that sets the override flag for stats injection.
+    """
+    assert not request.user.is_superuser
+    request._cavalry_can_inject_stats = bool(request.GET.get("plsplspls"))
+    return regular_view(request)
+
+
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("", TemplateView.as_view(template_name="index.html")),
+    path("", regular_view),
     path("streaming/", streaming_view),
+    path("overrider/", overrider_view),
 ]


### PR DESCRIPTION
A middleware may want to enable stats injection for any arbitrary request; make it so.